### PR TITLE
Hairpin reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,27 @@ Badread is published in the [Journal of Open Source Software](http://joss.theoj.
 
 ## Table of contents
 
-* [Requirements](#requirements)
-* [Installation](#installation)
-* [Quick usage](#quick-usage)
-* [Method](#method)
-* [Detailed usage](#detailed-usage)
-  * [Command line](#command-line)
-  * [Reference FASTA](#reference-fasta)
-  * [Fragment lengths](#fragment-lengths)
-  * [Read identities](#read-identities)
-  * [Error model](#error-model)
-  * [QScore model](#qscore-model)
-  * [Adapters](#adapters)
-  * [Junk and random reads](#junk-and-random-reads)
-  * [Chimeras](#chimeras)
-  * [Small plasmid bias](#small-plasmid-bias)
-  * [Glitches](#glitches)
-* [Contributing](#contributing)
-* [License](#license)
+- [Table of contents](#table-of-contents)
+- [Requirements](#requirements)
+- [Installation](#installation)
+  - [Install from source](#install-from-source)
+  - [Run without installation](#run-without-installation)
+- [Quick usage](#quick-usage)
+- [Method](#method)
+- [Detailed usage](#detailed-usage)
+  - [Command line](#command-line)
+  - [Reference FASTA](#reference-fasta)
+  - [Fragment lengths](#fragment-lengths)
+  - [Read identities](#read-identities)
+  - [Error model](#error-model)
+  - [QScore model](#qscore-model)
+  - [Adapters](#adapters)
+  - [Junk and random reads](#junk-and-random-reads)
+  - [Chimeras](#chimeras)
+  - [Small plasmid bias](#small-plasmid-bias)
+  - [Glitches](#glitches)
+- [Contributing](#contributing)
+- [License](#license)
 
 
 
@@ -135,7 +138,7 @@ Here is an overview of how Badread makes each of its reads:
 1. Use the [fragment length distribution](#fragment-lengths) to choose a length for the read.
 
 2. Choose a type of fragment:
-    * Most will be fragments of sequence from the [reference FASTA](#reference-fasta). These are equally likely to come from either strand, and can loop around circular references. If there are multiple reference sequences with different depths, then the likelihood of the fragment coming from each sequence is proportional to that sequence's depth.
+    * Most will be fragments of sequence from the [reference FASTA](#reference-fasta). These are equally likely to come from either strand, and can loop around circular references or over hairpin ends. If there are multiple reference sequences with different depths, then the likelihood of the fragment coming from each sequence is proportional to that sequence's depth.
     * Depending on the settings, some fragments may also be [junk or random sequence](#junk-and-random-reads).
 
 3. Add adapter sequences to the start and end of the fragment, based on the [adapter settings](#adapters).
@@ -227,6 +230,8 @@ The reference genome must be given as a FASTA file (either gzipped or not) using
 Each sequence's depth can be specified in the FASTA header, e.g. using `depth=1.1` or `depth=15`. Badread will use this to determine the relative abundance of each sequence. This can be useful for both bacterial genomes (where plasmids may be higher depth than the chromosome) and eukaryote genomes (where chloroplast/mitochondrial genomes may be higher depth than the rest of the genome).
 
 Circular sequences are indicated by including `circular=true` in the FASTA header. This allows reads to loop past the end and back to the start of the sequence.
+
+Hairpin ends are also supported (thanks, [David](https://github.com/dalofa)). You can add `hairpin_left=true` or `hairpin_right=true` (or both) to make reads that hit the end of the sequence loop back on the opposite strand.
 
 For a couple of examples, check out [the reference FASTA page on the wiki](https://github.com/rrwick/Badread/wiki/Example-reference-FASTAs).
 

--- a/badread/error_model.py
+++ b/badread/error_model.py
@@ -29,7 +29,7 @@ from .misc import load_fasta, load_fastq, reverse_complement, random_chance, get
 
 
 def make_error_model(args, output=sys.stderr, dot_interval=1000):
-    refs, _, _,_,_ = load_fasta(args.reference)
+    refs, _, _, _, _ = load_fasta(args.reference)
     reads = load_fastq(args.reads, output=output)
     alignments = load_alignments(args.alignment, args.max_alignments, output=output)
     if len(alignments) == 0:

--- a/badread/error_model.py
+++ b/badread/error_model.py
@@ -29,7 +29,7 @@ from .misc import load_fasta, load_fastq, reverse_complement, random_chance, get
 
 
 def make_error_model(args, output=sys.stderr, dot_interval=1000):
-    refs, _, _ = load_fasta(args.reference)
+    refs, _, _,_,_ = load_fasta(args.reference)
     reads = load_fastq(args.reads, output=output)
     alignments = load_alignments(args.alignment, args.max_alignments, output=output)
     if len(alignments) == 0:

--- a/badread/misc.py
+++ b/badread/misc.py
@@ -122,7 +122,7 @@ def load_fastq(filename, output=sys.stderr, dot_interval=1000):
 
 def load_fasta(filename):
     fasta_seqs = collections.OrderedDict()
-    depths, circular = {}, {}
+    depths, circular, hairpin_left, hairpin_right = {}, {}, {}, {}
     p = re.compile(r'depth=([\d.]+)')
     with get_open_func(filename)(filename, 'rt') as fasta_file:
         name = ''
@@ -145,11 +145,13 @@ def load_fasta(filename):
                 else:
                     depths[short_name] = 1.0
                 circular[short_name] = 'circular=true' in name.lower()
+                hairpin_left[short_name] = 'hairpin_left=true' in name.lower()
+                hairpin_right[short_name] = 'hairpin_right=true' in name.lower()
             else:
                 sequence.append(line)
         if name:
             fasta_seqs[name.split()[0]] = ''.join(sequence).upper()
-    return fasta_seqs, depths, circular
+    return fasta_seqs, depths, circular, hairpin_left, hairpin_right
 
 
 RANDOM_SEQ_DICT = {0: 'A', 1: 'C', 2: 'G', 3: 'T'}

--- a/badread/plot_window_identity.py
+++ b/badread/plot_window_identity.py
@@ -26,7 +26,7 @@ from .qscore_model import qscore_char_to_val
 
 def plot_window_identity(args, output=sys.stdout):
     reads = load_fastq(args.reads, output=output)
-    refs, _, _,_,_ = load_fasta(args.reference)
+    refs, _, _, _, _ = load_fasta(args.reference)
     alignments = load_alignments(args.alignment, output=output)
 
     for a in alignments:

--- a/badread/plot_window_identity.py
+++ b/badread/plot_window_identity.py
@@ -26,7 +26,7 @@ from .qscore_model import qscore_char_to_val
 
 def plot_window_identity(args, output=sys.stdout):
     reads = load_fastq(args.reads, output=output)
-    refs, _, _ = load_fasta(args.reference)
+    refs, _, _,_,_ = load_fasta(args.reference)
     alignments = load_alignments(args.alignment, output=output)
 
     for a in alignments:

--- a/badread/qscore_model.py
+++ b/badread/qscore_model.py
@@ -76,7 +76,7 @@ def get_qscores(seq, frag, qscore_model):
 
 
 def make_qscore_model(args, output=sys.stderr, dot_interval=1000):
-    refs, _, _,_,_ = load_fasta(args.reference)
+    refs, _, _, _, _ = load_fasta(args.reference)
     reads = load_fastq(args.reads, output=output)
     alignments = load_alignments(args.alignment, args.max_alignments, output=output)
     if len(alignments) == 0:

--- a/badread/qscore_model.py
+++ b/badread/qscore_model.py
@@ -76,7 +76,7 @@ def get_qscores(seq, frag, qscore_model):
 
 
 def make_qscore_model(args, output=sys.stderr, dot_interval=1000):
-    refs, _, _ = load_fasta(args.reference)
+    refs, _, _,_,_ = load_fasta(args.reference)
     reads = load_fastq(args.reads, output=output)
     alignments = load_alignments(args.alignment, args.max_alignments, output=output)
     if len(alignments) == 0:

--- a/badread/simulate.py
+++ b/badread/simulate.py
@@ -34,7 +34,7 @@ def simulate(args, output=sys.stderr):
     if args.seed is not None:
         random.seed(args.seed)
         np.random.seed(args.seed)
-    ref_seqs, ref_depths, ref_circular = load_reference(args.reference, output)
+    ref_seqs, ref_depths, ref_circular, left_hairpin, right_hairpin = load_reference(args.reference, output)
     rev_comp_ref_seqs = {name: reverse_complement(seq) for name, seq in ref_seqs.items()}
     frag_lengths = FragmentLengths(args.mean_frag_length, args.frag_length_stdev, output)
     adjust_depths(ref_seqs, ref_depths, ref_circular, frag_lengths, args)
@@ -89,7 +89,7 @@ def simulate(args, output=sys.stderr):
 
 
 def build_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs, ref_contigs, ref_contig_weights,
-                   ref_circular, args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
+                   ref_circular, left_hairpin, right_hairpin, args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                    end_adapt_amount):
     fragment = [get_start_adapter(start_adapt_rate, start_adapt_amount, args.start_adapter_seq)]
     info = []
@@ -105,7 +105,7 @@ def build_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs, ref_contigs, ref_c
         if random_chance(settings.CHIMERA_START_ADAPTER_CHANCE):
             fragment.append(args.start_adapter_seq)
         frag_seq, frag_info = get_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs,
-                                           ref_contigs, ref_contig_weights, ref_circular, args)
+                                           ref_contigs, ref_contig_weights, ref_circular, left_hairpin, right_hairpin, args)
         fragment.append(frag_seq)
         info.append(','.join(frag_info))
     fragment.append(get_end_adapter(end_adapt_rate, end_adapt_amount, args.end_adapter_seq))
@@ -146,7 +146,7 @@ def get_target_size(ref_size, quantity):
 
 
 def get_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs, ref_contigs, ref_contig_weights,
-                 ref_circular, args):
+                 ref_circular, left_hairpin, right_hairpin args):
     fragment_length = frag_lengths.get_fragment_length()
     fragment_type = get_fragment_type(args)
     if fragment_type == 'junk':
@@ -158,7 +158,7 @@ def get_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs, ref_contigs, ref_con
     # repeatedly until we get a result.
     for _ in range(1000):
         seq, info = get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
-                                      ref_contig_weights, ref_circular)
+                                      ref_contig_weights, ref_circular, left_hairpin, right_hairpin)
         if seq != '':
             return seq, info
     sys.exit('Error: failed to generate any sequence fragments - are your read lengths '
@@ -181,23 +181,31 @@ def get_fragment_type(args):
 
 
 def get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
-                      ref_contig_weights, ref_circular):
+                      ref_contig_weights, ref_circular, left_hairpin, right_hairpin):
 
     if len(ref_contigs) == 1:
         contig = ref_contigs[0]
     else:
         contig = random.choices(ref_contigs, weights=ref_contig_weights)[0]
+
     info = [contig]
     if random_chance(0.5):
         seq = ref_seqs[contig]
+        rv_seq = rev_comp_ref_seqs[contig] # save to use for hairpin
         info.append('+strand')
+        strand = '+'
     else:
         seq = rev_comp_ref_seqs[contig]
+        rv_seq = ref_seqs[contig] # save to use for hairpin
         info.append('-strand')
+        strand = '-'
+
+    # is there a hairpin at the relevant end of the contig?
+    hairpin_at_end= (right_hairpin[contig] if strand == '+' else left_hairpin[contig])
 
     # If the reference contig is linear and the fragment length is long enough, then we just
     # return the entire fragment, start to end.
-    if fragment_length >= len(seq) and not ref_circular[contig]:
+    if fragment_length >= len(seq) and not ref_circular[contig] and not hairpin_at_end:
         info.append('0-' + str(len(seq)))
         return seq, info
 
@@ -209,13 +217,6 @@ def get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
     start_pos = random.randint(0, len(seq)-1)
     end_pos = start_pos + fragment_length
 
-    # The ending position might be past the end of the sequence. If the sequence is linear, we
-    # fix this now.
-    if not ref_circular[contig] and end_pos > len(seq):
-        end_pos = len(seq)
-
-    info.append(f'{start_pos}-{end_pos}')
-
     # For circular contigs, we may have to loop the read around the contig.
     if ref_circular[contig]:
         if end_pos <= len(seq):
@@ -223,11 +224,37 @@ def get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
         else:
             looped_end_pos = end_pos - len(seq)
             assert looped_end_pos > 0
+
+        info.append(f'{start_pos}-{end_pos}')
         return seq[start_pos:] + seq[:looped_end_pos], info
 
-    # For linear contigs, no looping is needed.
-    else:
-        return seq[start_pos:end_pos], info
+    # The ending position might be past the end of the sequence. If the sequence is linear, we
+    # fix this now.
+
+    if not ref_circular[contig] and end_pos > len(seq):
+        # If the read would extend past the end of a linear contigs with
+        # a hairpin at the end, we allow it to extend through the hairpin
+        # into the other strand (reverse complement)
+        if hairpin_at_end:
+            fwd_seq = seq[start_pos:]
+            left_over_bases = fragment_length - len(fwd_seq)
+
+            # do not allow multiple hairpin loops
+            # as I have observed this in real data so far
+            if left_over_bases > len(rv_seq): 
+                return '', ''  # read would extend past the end of the other strand, so we fail to get the read
+
+            if left_over_bases > 0:
+                hp_seq = rv_seq[:left_over_bases]
+            else:
+                hp_seq = ''
+            info.append(f'{start_pos}-{len(seq)} (hairpin) 0-{left_over_bases}')
+            return fwd_seq + hp_seq, info
+
+        # If there is no hairpin terminate at contig end.
+        end_pos = len(seq)
+        info.append(f'{start_pos}-{end_pos}')
+    return seq[start_pos:end_pos], info
 
 
 def get_junk_fragment(fragment_length):
@@ -478,7 +505,7 @@ def print_progress(count, bp, target, output):
 def load_reference(reference, output):
     print('', file=output)
     print(f'Loading reference from {reference}', file=output)
-    ref_seqs, ref_depths, ref_circular = load_fasta(reference)
+    ref_seqs, ref_depths, ref_circular, left_hairpin, right_hairpin = load_fasta(reference)
     plural = '' if len(ref_seqs) == 1 else 's'
     print(f'  {len(ref_seqs):,} contig{plural}:', file=output)
     for contig in ref_seqs:
@@ -488,7 +515,7 @@ def load_reference(reference, output):
     if len(ref_seqs) > 1:
         total_size = sum(len(s) for s in ref_seqs.values())
         print(f'  total size: {total_size:,} bp', file=output)
-    return ref_seqs, ref_depths, ref_circular
+    return ref_seqs, ref_depths, ref_circular, left_hairpin, right_hairpin
 
 
 def print_intro(output):

--- a/badread/simulate.py
+++ b/badread/simulate.py
@@ -62,8 +62,8 @@ def simulate(args, output=sys.stderr):
     print_progress(count, total_size, target_size, output)
     while total_size < target_size:
         fragment, info = build_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs, ref_contigs,
-                                        ref_contig_weights, ref_circular, args, start_adapt_rate,
-                                        start_adapt_amount, end_adapt_rate, end_adapt_amount)
+                                        ref_contig_weights, ref_circular, left_hairpin, right_hairpin,
+                                        args, start_adapt_rate, start_adapt_amount, end_adapt_rate, end_adapt_amount)
         target_identity = identities.get_identity()
         seq, quals, actual_identity, identity_by_qscores = \
             sequence_fragment(fragment, target_identity, error_model, qscore_model)
@@ -94,7 +94,7 @@ def build_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs, ref_contigs, ref_c
     fragment = [get_start_adapter(start_adapt_rate, start_adapt_amount, args.start_adapter_seq)]
     info = []
     frag_seq, frag_info = get_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs,
-                                       ref_contigs, ref_contig_weights, ref_circular, args)
+                                       ref_contigs, ref_contig_weights, ref_circular, left_hairpin, right_hairpin, args)
     fragment.append(frag_seq)
     info.append(','.join(frag_info))
 
@@ -146,7 +146,7 @@ def get_target_size(ref_size, quantity):
 
 
 def get_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs, ref_contigs, ref_contig_weights,
-                 ref_circular, left_hairpin, right_hairpin args):
+                 ref_circular, left_hairpin, right_hairpin, args):
     fragment_length = frag_lengths.get_fragment_length()
     fragment_type = get_fragment_type(args)
     if fragment_type == 'junk':

--- a/badread/simulate.py
+++ b/badread/simulate.py
@@ -219,13 +219,13 @@ def get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
 
     # For circular contigs, we may have to loop the read around the contig.
     if ref_circular[contig]:
+        info.append(f'{start_pos}-{end_pos}')
         if end_pos <= len(seq):
             return seq[start_pos:end_pos], info
         else:
             looped_end_pos = end_pos - len(seq)
             assert looped_end_pos > 0
 
-        info.append(f'{start_pos}-{end_pos}')
         return seq[start_pos:] + seq[:looped_end_pos], info
 
     # The ending position might be past the end of the sequence. If the sequence is linear, we
@@ -253,7 +253,7 @@ def get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
 
         # If there is no hairpin terminate at contig end.
         end_pos = len(seq)
-        info.append(f'{start_pos}-{end_pos}')
+    info.append(f'{start_pos}-{end_pos}')
     return seq[start_pos:end_pos], info
 
 

--- a/badread/simulate.py
+++ b/badread/simulate.py
@@ -154,8 +154,8 @@ def get_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs, ref_contigs, ref_con
     elif fragment_type == 'random':
         return get_random_sequence(fragment_length), ['random_seq']
 
-    # The get_real_fragment function can return nothing (due to --small_plasmid_bias) so we try
-    # repeatedly until we get a result.
+    # The get_real_fragment function can return nothing (due to --small_plasmid_bias or hairpins)
+    # so we try repeatedly until we get a result.
     for _ in range(1000):
         seq, info = get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
                                       ref_contig_weights, ref_circular, left_hairpin, right_hairpin)
@@ -200,8 +200,7 @@ def get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
         info.append('-strand')
         strand = '-'
 
-    # is there a hairpin at the relevant end of the contig?
-    hairpin_at_end= (right_hairpin[contig] if strand == '+' else left_hairpin[contig])
+    hairpin_at_end = (right_hairpin[contig] if strand == '+' else left_hairpin[contig])
 
     # If the reference contig is linear and the fragment length is long enough, then we just
     # return the entire fragment, start to end.
@@ -228,21 +227,19 @@ def get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
 
         return seq[start_pos:] + seq[:looped_end_pos], info
 
-    # The ending position might be past the end of the sequence. If the sequence is linear, we
-    # fix this now.
+    # The ending position might be past the end of the sequence. If the sequence is linear, we fix
+    # this now.
 
     if not ref_circular[contig] and end_pos > len(seq):
-        # If the read would extend past the end of a linear contigs with
-        # a hairpin at the end, we allow it to extend through the hairpin
-        # into the other strand (reverse complement)
+        # If the read would extend past the end of a linear contigs with a hairpin at the end, we
+        # allow it to extend through the hairpin into the other strand (reverse complement).
         if hairpin_at_end:
             fwd_seq = seq[start_pos:]
             left_over_bases = fragment_length - len(fwd_seq)
 
-            # do not allow multiple hairpin loops
-            # as I have observed this in real data so far
+            # Do not allow multiple hairpin loops, as I have observed this in real data.
             if left_over_bases > len(rv_seq): 
-                return '', ''  # read would extend past the end of the other strand, so we fail to get the read
+                return '', ''
 
             if left_over_bases > 0:
                 hp_seq = rv_seq[:left_over_bases]

--- a/badread/simulate.py
+++ b/badread/simulate.py
@@ -189,18 +189,17 @@ def get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
         contig = random.choices(ref_contigs, weights=ref_contig_weights)[0]
 
     info = [contig]
+    seq = ref_seqs[contig]
+    rev_seq = rev_comp_ref_seqs[contig]
     if random_chance(0.5):
-        seq = ref_seqs[contig]
-        rv_seq = rev_comp_ref_seqs[contig] # save to use for hairpin
         info.append('+strand')
         strand = '+'
     else:
-        seq = rev_comp_ref_seqs[contig]
-        rv_seq = ref_seqs[contig] # save to use for hairpin
+        seq, rev_seq = rev_seq, seq
         info.append('-strand')
         strand = '-'
 
-    hairpin_at_end = (right_hairpin[contig] if strand == '+' else left_hairpin[contig])
+    hairpin_at_end = right_hairpin[contig] if strand == '+' else left_hairpin[contig]
 
     # If the reference contig is linear and the fragment length is long enough, then we just
     # return the entire fragment, start to end.
@@ -224,32 +223,25 @@ def get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
         else:
             looped_end_pos = end_pos - len(seq)
             assert looped_end_pos > 0
-
-        return seq[start_pos:] + seq[:looped_end_pos], info
+            return seq[start_pos:] + seq[:looped_end_pos], info
 
     # The ending position might be past the end of the sequence. If the sequence is linear, we fix
     # this now.
 
-    if not ref_circular[contig] and end_pos > len(seq):
-        # If the read would extend past the end of a linear contigs with a hairpin at the end, we
-        # allow it to extend through the hairpin into the other strand (reverse complement).
+    if end_pos > len(seq):
+        # If the read would extend past the end of a linear contig with a hairpin at the end, we
+        # allow it to extend through the hairpin into the other strand (reverse complement), but
+        # only as far as the mirrored starting position.
         if hairpin_at_end:
             fwd_seq = seq[start_pos:]
-            left_over_bases = fragment_length - len(fwd_seq)
-
-            # Do not allow multiple hairpin loops, as I have observed this in real data.
-            if left_over_bases > len(rv_seq): 
-                return '', ''
-
-            if left_over_bases > 0:
-                hp_seq = rv_seq[:left_over_bases]
-            else:
-                hp_seq = ''
+            left_over_bases = min(fragment_length - len(fwd_seq), len(fwd_seq))
+            hairpin_seq = rev_seq[:left_over_bases]
             info.append(f'{start_pos}-{len(seq)} (hairpin) 0-{left_over_bases}')
-            return fwd_seq + hp_seq, info
+            return fwd_seq + hairpin_seq, info
 
-        # If there is no hairpin terminate at contig end.
+        # If there is no hairpin, terminate at contig end.
         end_pos = len(seq)
+
     info.append(f'{start_pos}-{end_pos}')
     return seq[start_pos:end_pos], info
 

--- a/badread/simulate.py
+++ b/badread/simulate.py
@@ -154,8 +154,8 @@ def get_fragment(frag_lengths, ref_seqs, rev_comp_ref_seqs, ref_contigs, ref_con
     elif fragment_type == 'random':
         return get_random_sequence(fragment_length), ['random_seq']
 
-    # The get_real_fragment function can return nothing (due to --small_plasmid_bias or hairpins)
-    # so we try repeatedly until we get a result.
+    # The get_real_fragment function can potentially return nothing, so we try repeatedly until we
+    # get a result.
     for _ in range(1000):
         seq, info = get_real_fragment(fragment_length, ref_seqs, rev_comp_ref_seqs, ref_contigs,
                                       ref_contig_weights, ref_circular, left_hairpin, right_hairpin)

--- a/test/test_fragments.py
+++ b/test/test_fragments.py
@@ -38,6 +38,8 @@ class TestLinearFragments(unittest.TestCase):
         self.ref_contigs, self.ref_contig_weights = \
             badread.simulate.get_ref_contig_weights(self.ref_seqs, self.ref_depths)
         self.trials = 100
+        self.hairpin_left = {'r': False}
+        self.hairpin_right = {'r': False}
 
     def tearDown(self):
         self.null.close()
@@ -59,8 +61,8 @@ class TestLinearFragments(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             if fragment in forward_ref:
                 forward_count += 1
@@ -104,8 +106,8 @@ class TestLinearFragments(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             self.assertTrue(fragment.startswith(args.start_adapter_seq))
             self.assertTrue(fragment.endswith(args.end_adapter_seq))
@@ -131,8 +133,8 @@ class TestLinearFragments(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             lengths.append(len(fragment))
         self.assertGreater(max(lengths), 1000)  # Chimeras make for some longer fragments
@@ -151,6 +153,8 @@ class TestCircularFragments(unittest.TestCase):
         self.ref_contigs, self.ref_contig_weights = \
             badread.simulate.get_ref_contig_weights(self.ref_seqs, self.ref_depths)
         self.trials = 100
+        self.hairpin_left = {'r': False}
+        self.hairpin_right = {'r': False}
 
     def tearDown(self):
         self.null.close()
@@ -172,8 +176,8 @@ class TestCircularFragments(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             if fragment in forward_ref:
                 forward_count += 1
@@ -201,8 +205,8 @@ class TestCircularFragments(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             self.assertTrue(fragment.startswith(args.start_adapter_seq))
             self.assertTrue(fragment.endswith(args.end_adapter_seq))
@@ -224,8 +228,8 @@ class TestCircularFragments(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             lengths.append(len(fragment))
             self.assertTrue(len(fragment) % 1000 == 0)
@@ -246,8 +250,8 @@ class TestCircularFragments(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             lengths.append(len(fragment))
         self.assertGreater(statistics.mean(lengths), 1000)
@@ -267,8 +271,8 @@ class TestCircularFragments(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             lengths.append(len(fragment))
         self.assertLess(statistics.mean(lengths), 1000)
@@ -289,8 +293,8 @@ class TestCircularFragments(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             if fragment in forward_ref:
                 forward_count += 1
@@ -318,6 +322,8 @@ class TestSmallPlasmidBias(unittest.TestCase):
         self.ref_contigs, self.ref_contig_weights = \
             badread.simulate.get_ref_contig_weights(self.ref_seqs, self.ref_depths)
         self.trials = 100
+        self.hairpin_left = {'r': False}
+        self.hairpin_right = {'r': False}
 
     def tearDown(self):
         self.null.close()
@@ -338,8 +344,8 @@ class TestSmallPlasmidBias(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             self.assertEqual(len(fragment), 1000)
 
@@ -358,6 +364,8 @@ class TestWholeRef(unittest.TestCase):
         self.ref_contigs, self.ref_contig_weights = \
             badread.simulate.get_ref_contig_weights(self.ref_seqs, self.ref_depths)
         self.trials = 100
+        self.hairpin_left = {'r': False}
+        self.hairpin_right = {'r': False}
 
     def tearDown(self):
         self.null.close()
@@ -377,8 +385,8 @@ class TestWholeRef(unittest.TestCase):
             fragment, info = \
                 badread.simulate.build_fragment(self.lengths, self.ref_seqs, self.rev_comp_ref_seqs,
                                                 self.ref_contigs, self.ref_contig_weights,
-                                                self.ref_circular, args, start_adapt_rate,
-                                                start_adapt_amount, end_adapt_rate,
+                                                self.ref_circular, self.hairpin_left, self.hairpin_right,
+                                                args, start_adapt_rate, start_adapt_amount, end_adapt_rate,
                                                 end_adapt_amount)
             self.assertEqual(len(fragment), 1000)
             if fragment == self.ref_seqs['r']:
@@ -411,3 +419,50 @@ class TestRandomJunk(unittest.TestCase):
             random_seq = badread.simulate.get_junk_fragment(self.seq_len)
             compressed_seq = zlib.compress(random_seq.encode())
             self.assertLess(len(compressed_seq), len(random_seq) / 10)
+
+class TestHairpinReadthrough(unittest.TestCase):
+
+    def setUp(self):
+        self.null = open(os.devnull, 'w')
+        self.ref_len = 1000
+        self.ref_seqs = {'r': badread.misc.get_random_sequence(self.ref_len)}
+        self.rev_comp_ref_seqs = {'r': badread.misc.reverse_complement(self.ref_seqs['r'])}
+        self.ref_depths = {'r': 1.0}
+        self.ref_circular = {'r': False}
+        self.left_hairpin = {'r': True}
+        self.right_hairpin = {'r': True}
+        self.ref_contigs, self.ref_contig_weights = badread.simulate.get_ref_contig_weights(
+            self.ref_seqs, self.ref_depths)
+        self.trials = 100
+
+    def tearDown(self):
+        self.null.close()
+
+    def test_readthrough_happens(self):
+        # fragment > contig guarantees overrun on linear contig
+        frag_len = 1001 # always leads to tread through, but does not lead to multi-loop readthrough
+        lengths = badread.fragment_lengths.FragmentLengths(frag_len, 0, self.null)
+
+        for _ in range(self.trials):
+            seq, info = badread.simulate.get_real_fragment(
+                frag_len, self.ref_seqs, self.rev_comp_ref_seqs, self.ref_contigs,
+                self.ref_contig_weights, self.ref_circular, self.left_hairpin,
+                self.right_hairpin
+            )
+            self.assertNotEqual(seq, '')
+            self.assertEqual(len(seq), frag_len)
+            self.assertTrue(any('hairpin' in x for x in info))
+
+    def test_no_multi_loop_readthrough(self):
+        # In the current implementation only one hairpin can be read-through
+        # leftover always > opposite strand length, so function must reject
+        frag_len = 2500
+
+        for _ in range(self.trials):
+            seq, info = badread.simulate.get_real_fragment(
+                frag_len, self.ref_seqs, self.rev_comp_ref_seqs, self.ref_contigs,
+                self.ref_contig_weights, self.ref_circular, self.left_hairpin,
+                self.right_hairpin
+            )
+            self.assertEqual(seq, '')
+            self.assertEqual(info, '')

--- a/test/test_fragments.py
+++ b/test/test_fragments.py
@@ -440,8 +440,7 @@ class TestHairpinReadthrough(unittest.TestCase):
 
     def test_readthrough_happens(self):
         # fragment > contig guarantees overrun on linear contig
-        frag_len = 1001 # always leads to tread through, but does not lead to multi-loop readthrough
-        lengths = badread.fragment_lengths.FragmentLengths(frag_len, 0, self.null)
+        frag_len = 1001
 
         for _ in range(self.trials):
             seq, info = badread.simulate.get_real_fragment(
@@ -450,12 +449,13 @@ class TestHairpinReadthrough(unittest.TestCase):
                 self.right_hairpin
             )
             self.assertNotEqual(seq, '')
-            self.assertEqual(len(seq), frag_len)
             self.assertTrue(any('hairpin' in x for x in info))
+            start_pos = int(info[2].split('-', 1)[0])
+            self.assertEqual(len(seq), min(frag_len, 2 * (self.ref_len - start_pos)))
 
     def test_no_multi_loop_readthrough(self):
-        # In the current implementation only one hairpin can be read-through
-        # leftover always > opposite strand length, so function must reject
+        # Reads that would extend too far after a hairpin are truncated at the mirrored start
+        # position instead of looping again.
         frag_len = 2500
 
         for _ in range(self.trials):
@@ -464,5 +464,7 @@ class TestHairpinReadthrough(unittest.TestCase):
                 self.ref_contig_weights, self.ref_circular, self.left_hairpin,
                 self.right_hairpin
             )
-            self.assertEqual(seq, '')
-            self.assertEqual(info, '')
+            self.assertNotEqual(seq, '')
+            self.assertTrue(any('hairpin' in x for x in info))
+            start_pos = int(info[2].split('-', 1)[0])
+            self.assertEqual(len(seq), 2 * (self.ref_len - start_pos))

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -151,7 +151,7 @@ class TestLoadSequences(unittest.TestCase):
 
     def test_load_gzipped_fasta(self):
         filename = os.path.join(os.path.dirname(__file__), 'test_ref_1.fasta.gz')
-        seqs, depths, circular,_,_ = badread.misc.load_fasta(filename)
+        seqs, depths, circular, _, _ = badread.misc.load_fasta(filename)
         self.check_fasta(seqs, depths, circular)
 
     def test_load_bad_format_fasta(self):

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -146,17 +146,17 @@ class TestLoadSequences(unittest.TestCase):
 
     def test_load_non_gzipped_fasta(self):
         filename = os.path.join(os.path.dirname(__file__), 'test_ref_1.fasta')
-        seqs, depths, circular = badread.misc.load_fasta(filename)
+        seqs, depths, circular, _, _ = badread.misc.load_fasta(filename)
         self.check_fasta(seqs, depths, circular)
 
     def test_load_gzipped_fasta(self):
         filename = os.path.join(os.path.dirname(__file__), 'test_ref_1.fasta.gz')
-        seqs, depths, circular = badread.misc.load_fasta(filename)
+        seqs, depths, circular,_,_ = badread.misc.load_fasta(filename)
         self.check_fasta(seqs, depths, circular)
 
     def test_load_bad_format_fasta(self):
         filename = os.path.join(os.path.dirname(__file__), 'test_ref_1_bad.fasta')
-        seqs, depths, circular = badread.misc.load_fasta(filename)
+        seqs, depths, circular, _, _ = badread.misc.load_fasta(filename)
         self.check_fasta(seqs, depths, circular)
 
     def test_load_fastq(self):

--- a/test/test_references.py
+++ b/test/test_references.py
@@ -25,7 +25,7 @@ class TestLinearFragments(unittest.TestCase):
     def setUp(self):
         null = open(os.devnull, 'w')
         ref_filename = os.path.join(os.path.dirname(__file__), 'test_ref_1.fasta')
-        self.ref_seqs, self.ref_depths, self.ref_circular = \
+        self.ref_seqs, self.ref_depths, self.ref_circular, _, _ = \
             badread.simulate.load_reference(ref_filename, output=null)
         null.close()
 


### PR DESCRIPTION
Hi Ryan

As we discussed I have implemented hairpin read-through for linear contigs with a `hairpin_left=true` or `hairpin_right=true` in the FASTA header. I decided to only allow a single read-through, so currently multi-passes for a contig with two hairpins is not implemented.

I have added relevant unit tests to the testfragments.py. Additionally, I have updated several tests/modules to use the updated functions for load_fasta and load_reference since they now also return information on hairpins.